### PR TITLE
fix output of 'kube-aws node-pools init`

### DIFF
--- a/cmd/nodepool/init.go
+++ b/cmd/nodepool/init.go
@@ -129,9 +129,9 @@ func runCmdInit(cmd *cobra.Command, args []string) error {
 
 Next steps:
 1. (Optional) Edit %s to parameterize the cluster.
-2. Use the "kube-aws nodepool render" command to render the stack template.
+2. Use the "kube-aws node-pools render" command to render the stack template.
 `
 
-	fmt.Printf(successMsg, nodePoolClusterConfigFilePath, nodePoolClusterConfigFilePath)
+	fmt.Printf(successMsg, nodePoolClusterConfigFilePath(), nodePoolClusterConfigFilePath())
 	return nil
 }


### PR DESCRIPTION
- fix typo of `nodepools' with correct `node-pools`
- `nodePoolClusterConfigFilePath` should be evauated value of
`nodePoolClusterConfigFilePath` function.